### PR TITLE
Fix case opening animation bugs and mines cashout error

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6216,6 +6216,12 @@ function showCaseOpeningModal(caseName, wonItem, caseItems) {
     title.textContent = `Opening ${caseName}`;
     modal.classList.remove('hidden');
     
+    // Reset skip button to be visible for new case opening
+    const skipBtn = document.getElementById('skip-animation-btn');
+    if (skipBtn) {
+        skipBtn.style.display = 'flex';
+    }
+    
     // Hide result initially and remove any previous classes
     result.classList.add('hidden');
     result.classList.remove('show-result');
@@ -6441,6 +6447,11 @@ function showCaseOpeningModal(caseName, wonItem, caseItems) {
             
             // Handle item image/icon with robust fallback
             const wonItemImage = document.getElementById('won-item-image');
+            
+            // Clear any existing icon containers first
+            const existingIcons = wonItemImage.parentNode.querySelectorAll('.item-icon-large');
+            existingIcons.forEach(icon => icon.remove());
+            
             const imagePath = wonItem.image && wonItem.image !== 'default-item.png' ? 
                 (wonItem.image.startsWith('http') ? wonItem.image : `/images/${wonItem.image}`) : null;
             
@@ -6547,6 +6558,11 @@ function skipCaseAnimation() {
     
     // Handle item image/icon with robust fallback
     const wonItemImage = document.getElementById('won-item-image');
+    
+    // Clear any existing icon containers first
+    const existingIcons = wonItemImage.parentNode.querySelectorAll('.item-icon-large');
+    existingIcons.forEach(icon => icon.remove());
+    
     const imagePath = wonItem.image && wonItem.image !== 'default-item.png' ? 
         (wonItem.image.startsWith('http') ? wonItem.image : `/images/${wonItem.image}`) : null;
     
@@ -6696,6 +6712,12 @@ function closeCaseOpeningModal() {
         // Clean up any icon containers
         const iconContainers = modal.querySelectorAll('.item-icon-large');
         iconContainers.forEach(container => container.remove());
+        
+        const wonItemImage = document.getElementById('won-item-image');
+        if (wonItemImage) {
+            wonItemImage.src = '';
+            wonItemImage.style.display = 'none';
+        }
         
         // Reset last won item
         lastWonItem = null;
@@ -7116,11 +7138,7 @@ function displayInventory(inventory) {
         
         itemCard.innerHTML = `
             <div class="item-image">
-                ${imagePath ? 
-                    `<img src="${imagePath}" alt="${item.itemName}" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" onload="this.style.display='block'; this.nextElementSibling.style.display='none';">` : 
-                    ''
-                }
-                <div class="item-icon rarity-${item.rarity}" style="${imagePath ? 'display: flex;' : 'display: flex;'}">
+                <div class="item-icon rarity-${item.rarity}" style="display: flex;">
                     <i data-lucide="${rarityIcons[item.rarity] || 'package'}"></i>
                 </div>
             </div>

--- a/server/routes/games.js
+++ b/server/routes/games.js
@@ -294,7 +294,7 @@ router.post('/mines/reveal', authenticateToken, async (req, res) => {
 });
 
 // Mines cash out endpoint
-router.post('/mines/cashout', authenticateToken, async (req, res) => {
+router.post('/mines/cashout', authenticateToken, fetchUserWithSession, async (req, res) => {
     try {
         const result = await withTransaction(async (session) => {
             const { gameId, revealedTiles, currentMultiplier } = req.body;
@@ -765,4 +765,4 @@ router.post('/blackjack/double', authenticateToken, fetchUserWithSession, async 
     }
 });
 
-module.exports = router;                
+module.exports = router;                  


### PR DESCRIPTION

# Fix case opening animation bugs and mines cashout error

## Summary

This PR fixes several critical bugs in the case opening system and mines game:

1. **Duplicate elements in item-image div** - Fixed by clearing existing icon containers before adding new ones in both `displayCaseOpeningResult` and `skipCaseAnimation` functions
2. **Skip button disappearing** - Fixed by properly resetting skip button visibility when opening new cases
3. **Previous case data persisting** - Enhanced modal cleanup to clear all state between case openings
4. **Mines cashout error** - Added missing `fetchUserWithSession` middleware to the mines cashout route
5. **404 image requests** - Replaced image-first with icon-first approach for inventory display to prevent unnecessary network requests

## Review & Testing Checklist for Human

- [ ] **Test case opening multiple times in sequence** - Verify no duplicate icons appear in the item-image div
- [ ] **Test skip animation functionality** - Open a case, skip animation, then open another case to ensure skip button is visible
- [ ] **Test mines cashout** - Verify the cashout functionality works without the `fetchUserWithSession` error
- [ ] **Check inventory display** - Confirm inventory items show icons instead of attempting to load images
- [ ] **Monitor browser network tab** - Ensure no 404 requests for missing item images

**Recommended test plan**: Open cases multiple times, use skip button, test mines game cashout, and check inventory display while monitoring browser console and network tab for errors.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Frontend["public/js/app.js<br/>showCaseOpeningModal()<br/>displayCaseOpeningResult()<br/>skipCaseAnimation()<br/>closeCaseOpeningModal()<br/>displayInventory()"]:::major-edit
    Backend["server/routes/games.js<br/>mines/cashout route"]:::minor-edit
    HTML["public/index.html<br/>case-opening-modal<br/>item-image div"]:::context
    Auth["server/middleware/auth.js<br/>fetchUserWithSession"]:::context
    
    Frontend --> HTML
    Backend --> Auth
    Frontend --> Backend
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: Unable to fully test backend functionality due to MongoDB connection issues during development
- **DOM manipulation focus**: Most changes involve careful state management in the case opening modal
- **Pattern consistency**: Mines cashout middleware addition follows the same pattern used by other game routes
- **Icon-first approach**: Inventory display now uses icons exclusively to avoid image loading issues

---


**Link to Devin run**: https://app.devin.ai/sessions/cb463e09928944fbb8c95f557e5c2d5c  
**Requested by**: @ThatQne
